### PR TITLE
Add plugin enable/disable toggle and test build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build & Release
 
 on:
   push:
@@ -6,7 +6,35 @@ on:
       - 'v*'
 
 jobs:
+  determine-build-type:
+    runs-on: ubuntu-latest
+    outputs:
+      is_test: ${{ steps.check.outputs.is_test }}
+      version: ${{ steps.check.outputs.version }}
+      build_name: ${{ steps.check.outputs.build_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine build type and version
+        id: check
+        run: |
+          tag="${{ github.ref_name }}"
+
+          # Check if this is a test tag (ends with -test)
+          if [[ "$tag" == *-test ]]; then
+            echo "is_test=true" >> "$GITHUB_OUTPUT"
+            version="${tag#v}"
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
+            echo "build_name=Test Release ${version}" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_test=false" >> "$GITHUB_OUTPUT"
+            version="${tag#v}"
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
+            echo "build_name=Release" >> "$GITHUB_OUTPUT"
+          fi
+
   build-plugin:
+    needs: determine-build-type
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,14 +48,14 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Validate and set version from tag
+      - name: Validate and set version
         run: |
-          tag="${GITHUB_REF_NAME}"
-          version="${tag#v}"
+          version="${{ needs.determine-build-type.outputs.version }}"
+          is_test="${{ needs.determine-build-type.outputs.is_test }}"
 
-          # Must be semver: MAJOR.MINOR.PATCH with optional -prerelease suffix
+          # Validate semver format: MAJOR.MINOR.PATCH with optional -suffix
           if ! echo "$version" | grep -qP '^\d+\.\d+\.\d+(-[a-zA-Z0-9]+[a-zA-Z0-9.]*)?$'; then
-            echo "::error::Invalid version '${version}'. Must match MAJOR.MINOR.PATCH (e.g. v1.2.3 or v1.2.3-rc1)"
+            echo "::error::Invalid version '${version}'. Must match MAJOR.MINOR.PATCH (e.g. 1.2.3, 1.2.3-rc1, or 1.2.3-test)"
             exit 1
           fi
 
@@ -41,7 +69,7 @@ jobs:
             fi
           done
 
-          echo "Setting version to ${version}"
+          echo "Setting version to ${version} (test: ${is_test})"
           jq --arg v "$version" '.version = $v' plugin.json > plugin.json.tmp && mv plugin.json.tmp plugin.json
           jq --arg v "$version" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
 
@@ -84,6 +112,8 @@ jobs:
           path: AudioForge.zip
 
   check-flatpak-changes:
+    needs: determine-build-type
+    if: needs.determine-build-type.outputs.is_test == 'false'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check.outputs.changed }}
@@ -126,8 +156,10 @@ jobs:
           fi
 
   build-flatpak:
-    needs: check-flatpak-changes
-    if: needs.check-flatpak-changes.outputs.changed == 'true'
+    needs: [determine-build-type, check-flatpak-changes]
+    if: |
+      (needs.determine-build-type.outputs.is_test == 'false' && needs.check-flatpak-changes.outputs.changed == 'true') ||
+      (needs.determine-build-type.outputs.is_test == 'true')
     runs-on: ubuntu-latest
     container:
       image: bilelmoussaoui/flatpak-github-actions:kde-6.7
@@ -148,8 +180,10 @@ jobs:
           path: jamesdsp.flatpak
 
   reuse-flatpak:
-    needs: check-flatpak-changes
-    if: needs.check-flatpak-changes.outputs.changed == 'false'
+    needs: [determine-build-type, check-flatpak-changes]
+    if: |
+      needs.determine-build-type.outputs.is_test == 'false' &&
+      needs.check-flatpak-changes.outputs.changed == 'false'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -168,7 +202,7 @@ jobs:
           path: jamesdsp.flatpak
 
   release:
-    needs: [build-plugin, build-flatpak, reuse-flatpak]
+    needs: [determine-build-type, build-plugin, build-flatpak, reuse-flatpak]
     if: always() && needs.build-plugin.result == 'success' && (needs.build-flatpak.result == 'success' || needs.reuse-flatpak.result == 'success')
     runs-on: ubuntu-latest
     permissions:
@@ -201,4 +235,6 @@ jobs:
           files: |
             AudioForge.zip
             jamesdsp.flatpak
-          generate_release_notes: true
+          prerelease: ${{ needs.determine-build-type.outputs.is_test == 'true' }}
+          name: ${{ needs.determine-build-type.outputs.build_name }}
+          generate_release_notes: ${{ needs.determine-build-type.outputs.is_test == 'false' }}

--- a/main.py
+++ b/main.py
@@ -33,10 +33,12 @@ class Setting(SettingDef):
     DSP_PAGE_ORDER = 'dspPageOrder'
     DISABLE_PROFILE_TOAST = 'disableProfileToasts'
     RESTART_PIPELINE_ON_DEVICE = 'restartPipelineOnDeviceDetect'
+    PLUGIN_ENABLED = 'pluginEnabled'
 
     class Defaults:
         ENABLE_IN_DESKTOP = True
         RESTART_PIPELINE_ON_DEVICE = []
+        PLUGIN_ENABLED = True
         
 
 class ProfileSetting(SettingDef):

--- a/src/components/qam/PluginEnabledToggle.tsx
+++ b/src/components/qam/PluginEnabledToggle.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react'
+import { WaitToggle } from '../waitable/WaitToggle'
+import { usePluginStateContext } from '../../hooks/contextHooks';
+import { PluginManager } from '../../controllers/PluginManager';
+import { useWaiter } from '../../hooks/useWaiter';
+
+export const PluginEnabledToggle: FC<{}> = () => {
+    const { data, setData } = usePluginStateContext();
+    if (!data) return;
+
+    const checked = data.settings.pluginEnabled !== false;
+    const onChange = useWaiter(async (value: boolean) => {
+        await PluginManager.updateSettings({ pluginEnabled: value });
+        if (value) await PluginManager.start();
+        else await PluginManager.killJDSP();
+        setData?.(data => data && ({ ...data, settings: { ...data.settings, pluginEnabled: value } }));
+    });
+
+    return <WaitToggle label='Enable plugin' checked={checked} onChange={onChange} />;
+}

--- a/src/components/qam/pager/QAMPluginSettingsPage.tsx
+++ b/src/components/qam/pager/QAMPluginSettingsPage.tsx
@@ -13,6 +13,7 @@ import { SiGithub, SiKofi } from "react-icons/si";
 import { ReorderDspPagesButton } from '../../other/ReorderDspPages';
 import { useUpdateSetting } from '../../../hooks/useUpdateSetting';
 import { DisableProfileToastsToggle } from '../DisableProfileToastsToggle';
+import { PluginEnabledToggle } from '../PluginEnabledToggle';
 import { PluginManager } from '../../../controllers/PluginManager';
 import { observer } from 'mobx-react-lite';
 import { WaitToggle } from '../../waitable/WaitToggle';
@@ -33,6 +34,9 @@ export const QAMPluginSettingsPage: FC<{}> = ({ }) => {
                     <QAMHiglightable>
                         <ReorderDspPagesButton currentOrder={data.settings.dspPageOrder} onConfirm={useUpdateSetting('dspPageOrder')} />
                     </QAMHiglightable>}
+                <PanelSectionRow>
+                    <PluginEnabledToggle />
+                </PanelSectionRow>
                 <PanelSectionRow>
                     <EnableInDesktopToggle />
                 </PanelSectionRow>

--- a/src/controllers/PluginManager.ts
+++ b/src/controllers/PluginManager.ts
@@ -68,11 +68,13 @@ export class PluginManager {
 
             this.promises.pluginSettings = Backend.initUser(this.currentUser!.id, this.currentUser!.name, this.currentUser!.persona).catch((e) => useError('Problem initializing user', e));
             const settings = await this.promises.pluginSettings;
+            const shouldStart = !(settings instanceof Error) && settings.pluginEnabled !== false;
             if (uiMode === EUIMode.Desktop) {
-                if (!(settings instanceof Error) && settings.enableInDesktop) this.start();
+                if (shouldStart && settings.enableInDesktop) this.start();
                 else this.killJDSP();
             } else {
-                this.start();
+                if (shouldStart) this.start();
+                else this.killJDSP();
             }
         }));
 
@@ -86,7 +88,7 @@ export class PluginManager {
         return dispose;
     }
 
-    private static async start() {
+    static async start() {
         profileManager.active = true;
         const audioDevices = (await SteamClient.System.Audio.GetDevices()).vecDevices.map(device => device.sName);
         audioDevices.forEach(device => !this.detectedAudioDevices.includes(device) && this.detectedAudioDevices.push(device));

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,6 +24,7 @@ export type PluginSettings = {
     dspPageOrder: DSPPageOrder;
     disableProfileToasts: boolean;
     restartPipelineOnDeviceDetect: string[];
+    pluginEnabled: boolean;
 };
 
 export type PluginStateData = {


### PR DESCRIPTION
## Summary

This PR introduces two major features:

### 1. Plugin Enable/Disable Toggle
- Users can now toggle JamesDSP on/off while keeping the plugin loaded
- Adds "Enable plugin" toggle to the QAM settings page
- Setting persists across reboots and respects mode changes
- When disabled, JamesDSP process is killed; when enabled, it's restarted

**Files changed:**
- `main.py` — Added pluginEnabled setting (default: enabled)
- `src/types/types.ts` — Added pluginEnabled to PluginSettings
- `src/controllers/PluginManager.ts` — Made start() public, updated UI mode handler
- `src/components/qam/PluginEnabledToggle.tsx` — New toggle component
- `src/components/qam/pager/QAMPluginSettingsPage.tsx` — Integrated toggle

### 2. Enhanced Build & Release Workflow
- Supports test and production releases via tag naming convention
- Test releases: use `v*-test` tags (e.g., `v1.0.0-test`) → creates pre-release
- Production releases: use `v*` tags (e.g., `v1.0.0`) → creates full release
- Test releases are marked as pre-releases on GitHub
- Production releases get auto-generated release notes

**Usage:**
\`\`\`bash
git tag v1.0.0-test          # Creates test pre-release
git tag v1.0.0               # Creates production release
git push origin --tags
\`\`\`

## Test plan

- [ ] Build and test frontend without errors
- [ ] Test plugin enable/disable toggle in QAM settings
- [ ] Verify setting persists after reboot
- [ ] Test mode switch respects disabled state
- [ ] Create a test tag and verify workflow executes
- [ ] Verify test release is marked as pre-release

🤖 Generated with Claude Code